### PR TITLE
Compare string value `true`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,12 +24,12 @@ runs:
         git remote set-url origin "https://x-access-token:${{ github.token }}@github.com/$GITHUB_REPOSITORY"
       shell: bash
     - name: Configure trusted publishing credentials
-      if: ${{ inputs.setup-trusted-publisher }}
+      if: ${{ inputs.setup-trusted-publisher == 'true' }}
       uses: rubygems/configure-rubygems-credentials@v1.0.0
     - name: Run release rake task
       run: bundle exec rake release
       shell: bash
     - name: Wait for release to propagate
-      if: ${{ inputs.await-release }}
+      if: ${{ inputs.await-release == 'true' }}
       run: gem exec rubygems-await pkg/*.gem
       shell: bash


### PR DESCRIPTION
GitHub Actions booleans aren't… really… booleans.

See: https://github.com/actions/runner/issues/1483

I tripped on this [here](https://github.com/jgarber623/sprockets-sass_embedded/actions/runs/7361651564/job/20039226386) with a configuration like:

```yaml
- uses: rubygems/release-gem@v1
  with:
    await-release: false
```

This configuration is valid, but is ignored owing to the current configuration. This proposed change _should_ address that.

The proposed change is consistent with behavior in other reusable actions (see [ruby/setup-ruby](https://github.com/ruby/setup-ruby), for instance).