### PR TITLE
Remove the requirement of having a Rakefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          bundler-cache: true
           ruby-version: ruby
 
       # Release

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
       if: ${{ inputs.setup-trusted-publisher }}
       uses: rubygems/configure-rubygems-credentials@v1.0.0
     - name: Run release rake task
-      run: bundle exec rake release
+      run: rake -f -r bundler/gem_tasks release
       shell: bash
     - name: Wait for release to propagate
       if: ${{ inputs.await-release }}


### PR DESCRIPTION
Currently this action runs `bundle exec rake release`, which has a few limitations:

- It requires all dependencies to be installed because of `bundle exec`.
- It requires a `Rakefile` to exist and the file has to require `bundler/gem_tasks`.

This PR update the command to `rake -f -r bundler/gem_tasks release`, which works without any dependencies or Rakefile. 

The `-f` without a filename indicate we don't want to source any Rakefile, `-r bundler/gem_tasks` loads the task for `release`.

- Closes #3.