### PR TITLE
update example in README to stop using cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          bundler-cache: true
+          bundler-cache: false
           ruby-version: ruby
-
+      - name: Install dependencies
+        run: bundle install --jobs 4
       # Release
       - uses: rubygems/release-gem@v1
 ```


### PR DESCRIPTION
Not reusing cache from other jobs can protect from cache poisoning, so it’s safer to reinstall dependencies from scratch in a release job.

I’ve explicitly set it to false (in case the default changes in setup-ruby), but maybe there should also be a comment about this either directly in this YAML or in its description above?

`--jobs 4` is what setup-ruby does.