### PR TITLE
Fetch git tags before running gem release

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,9 @@ runs:
         git config --global user.name "$(git log -1 --pretty=format:'%an')"
         git remote set-url origin "https://x-access-token:${{ github.token }}@github.com/$GITHUB_REPOSITORY"
       shell: bash
+    - name: Fetch tags
+      run: git fetch --tags
+      shell: bash
     - name: Configure trusted publishing credentials
       if: ${{ inputs.setup-trusted-publisher == 'true' }}
       uses: rubygems/configure-rubygems-credentials@v1.0.0


### PR DESCRIPTION
Adds a `git fetch --tags` step to ensure that tags are fetched before running the `bundle exec rake release` task.

This step is necessary to avoid errors when trying to push a tag that already exists remote. Without fetching the tags, the release process can fail with an error like:

```bash
Run bundle exec rake release
komeda 0.4.0 built to pkg/komeda-0.4.0.gem.
Tagged v0.4.0.
Untagging v0.4.0 due to error.
rake aborted!
Running `git push origin refs/tags/v0.4.0` failed with the following output:

To https://github.com/ytkg/komeda
 ! [rejected]        v0.4.0 -> v0.4.0 (already exists)
error: failed to push some refs to 'https://github.com/ytkg/komeda'
hint: Updates were rejected because the tag already exists in the remote.
```

This change ensures that the action fetches the latest tags from the remote repository, preventing conflicts when tags already exist, and allows the release process to continue smoothly.