### PR TITLE
Use Git's credential helper to manage secrets

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,11 @@ runs:
         # Attribute commits to the last committer on HEAD
         git config --global user.email "$(git log -1 --pretty=format:'%ae')"
         git config --global user.name "$(git log -1 --pretty=format:'%an')"
-        git remote set-url origin "https://x-access-token:${{ github.token }}@github.com/$GITHUB_REPOSITORY"
+
+        # Use Git's credential helper to keep secrets from being written to disk
+        git config --global credential.helper '!f() { echo "username=x-access-token"; echo "password=${{ github.token }}"; }; f'
+
+        git remote set-url origin "https://github.com/$GITHUB_REPOSITORY"
       shell: bash
     - name: Configure trusted publishing credentials
       if: ${{ inputs.setup-trusted-publisher == 'true' }}


### PR DESCRIPTION
This is being done to prevent writing a secret to the `.git/config` file.