### PR TITLE
Update example to opt out of persisting credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ jobs:
     steps:
       # Set up
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
Since this is an example to be used by others, it makes sense (to me) to explicitly opt out of storing credentials in `.git/config`