### PR TITLE
Prevent credentials from being written to disk

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,10 +28,16 @@ runs:
         git config --global user.email "$(git log -1 --pretty=format:'%ae')"
         git config --global user.name "$(git log -1 --pretty=format:'%an')"
       shell: bash
-    - name: Configure temporary Git credentials
+    - name: Configure Git using cached credentials
       run: |
+        git credential-cache --timeout=300 store <<EOF
+        protocol=https
+        host=github.com
+        username=x-access-token
+        password=${{ github.token }}
+
+        EOF
         git config --local credential.helper 'cache --timeout=300'
-        echo -e "protocol=https\nhost=github.com\nusername=x-access-token\npassword=${{ github.token }}" | git credential approve
       shell: bash
     - name: Configure trusted publishing credentials
       if: ${{ inputs.setup-trusted-publisher == 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -23,12 +23,15 @@ branding:
 runs:
   using: "composite"
   steps:
-    - name: Set remote URL
+    - name: Attribute commits to last committer
       run: |
-        # Attribute commits to the last committer on HEAD
         git config --global user.email "$(git log -1 --pretty=format:'%ae')"
         git config --global user.name "$(git log -1 --pretty=format:'%an')"
-        git remote set-url origin "https://x-access-token:${{ github.token }}@github.com/$GITHUB_REPOSITORY"
+      shell: bash
+    - name: Configure temporary Git credentials
+      run: |
+        git config --local credential.helper 'cache --timeout=300'
+        echo -e "protocol=https\nhost=github.com\nusername=x-access-token\npassword=${{ github.token }}" | git credential approve
       shell: bash
     - name: Configure trusted publishing credentials
       if: ${{ inputs.setup-trusted-publisher == 'true' }}
@@ -41,4 +44,8 @@ runs:
     - name: Wait for release to propagate
       if: ${{ inputs.await-release == 'true' }}
       run: gem exec rubygems-await pkg/*.gem
+      shell: bash
+    - name: Clean up credentials
+      if: always()
+      run: git credential-cache exit || true
       shell: bash


### PR DESCRIPTION
I had made a [previous attempt](https://github.com/rubygems/release-gem/pull/18) at this, but used an approach that wrote credentials to `~/.gitconfig`. By piping credentials to `git credentials approve` we eliminate writing credentials altogether. Additionally, we're now cleaning up the credential cache before completing the workflow.

🤔 Open question: is a timeout of five minutes sufficient?