### PR TITLE
Use a SHA until the next gem version is released

### DIFF
--- a/rubygems-attestation-patch.rb
+++ b/rubygems-attestation-patch.rb
@@ -49,28 +49,17 @@ Gem::Commands::PushCommand.prepend(Module.new do
     out, st = Open3.capture2e(*checkout_cmd)
     raise Gem::Exception, "Failed to checkout SHA:\n\n#{out}" unless st.success?
 
-    # Add sigstore-ruby lib directories to load path
-    sigstore_lib = File.join(tmpdir, "lib")
-    cli_lib = File.join(tmpdir, "cli", "lib")
-    $LOAD_PATH.unshift(sigstore_lib, cli_lib)
-
-    # Require the sigstore CLI code
-    begin
-      require "sigstore/cli"
-    rescue => e
-      raise Gem::Exception, "Failed to load sigstore CLI: #{e.message}"
-    end
+    # Install dependencies with bundler
+    bundle_install_cmd = ["bundle", "install", "--quiet"]
+    out, st = Open3.capture2e(*bundle_install_cmd, chdir: tmpdir)
+    raise Gem::Exception, "Failed to install sigstore dependencies:\n\n#{out}" unless st.success?
 
     bundle = "#{name}.sigstore.json"
 
-    # Call the CLI directly with the sign command
-    begin
-      Sigstore::CLI.start(["sign", name, "--bundle", bundle])
-    rescue SystemExit => e
-      raise Gem::Exception, "Failed to sign gem: CLI exited with status #{e.status}" unless e.status == 0
-    rescue => e
-      raise Gem::Exception, "Failed to sign gem: #{e.message}"
-    end
+    # Run sigstore-cli using bundle exec
+    cli_cmd = ["bundle", "exec", "bin/sigstore-cli", "sign", name, "--bundle", bundle]
+    out, st = Open3.capture2e(*cli_cmd, chdir: tmpdir)
+    raise Gem::Exception, "Failed to sign gem:\n\n#{out}" unless st.success?
 
     bundle
   ensure

--- a/rubygems-attestation-patch.rb
+++ b/rubygems-attestation-patch.rb
@@ -45,24 +45,16 @@ Gem::Commands::PushCommand.prepend(Module.new do
     puts "[ATTESTATION DEBUG] attest! method called for #{name}"
     require "open3"
 
-    # Install specific_install gem
-    puts "[ATTESTATION DEBUG] Installing specific_install gem"
-    install_specific_install = [Gem.ruby, "-S", "gem", "install", "specific_install", "--no-document"]
-    puts "[ATTESTATION DEBUG] Running: #{install_specific_install.inspect}"
-    out, st = Open3.capture2e(*install_specific_install)
-    puts "[ATTESTATION DEBUG] specific_install install output:\n#{out}"
-    raise Gem::Exception, "Failed to install specific_install:\n\n#{out}" unless st.success?
-
-    # Use specific_install to install sigstore from the GitHub SHA
-    puts "[ATTESTATION DEBUG] Using specific_install to install sigstore from GitHub SHA"
-    specific_install_cmd = [
-      Gem.ruby, "-S", "gem", "specific_install",
-      "-l", "https://github.com/sigstore/sigstore-ruby",
-      "-b", "ce93acf7fa7e26ba81ff21820848d7df2273a557"
+    # Install sigstore and sigstore-cli from the GitHub SHA
+    puts "[ATTESTATION DEBUG] Installing sigstore from GitHub SHA"
+    install_cmd = [
+      Gem.ruby, "-S", "gem", "install",
+      "--no-document",
+      "git+https://github.com/sigstore/sigstore-ruby.git@ce93acf7fa7e26ba81ff21820848d7df2273a557"
     ]
-    puts "[ATTESTATION DEBUG] Running: #{specific_install_cmd.inspect}"
-    out, st = Open3.capture2e(*specific_install_cmd)
-    puts "[ATTESTATION DEBUG] specific_install output:\n#{out}"
+    puts "[ATTESTATION DEBUG] Running: #{install_cmd.inspect}"
+    out, st = Open3.capture2e(*install_cmd)
+    puts "[ATTESTATION DEBUG] Install output:\n#{out}"
     raise Gem::Exception, "Failed to install sigstore from GitHub:\n\n#{out}" unless st.success?
     puts "[ATTESTATION DEBUG] Gem installation succeeded"
 

--- a/rubygems-attestation-patch.rb
+++ b/rubygems-attestation-patch.rb
@@ -7,22 +7,30 @@ require "rubygems/commands/push_command"
 
 Gem::Commands::PushCommand.prepend(Module.new do
   def send_push_request(name, args)
+    puts "[ATTESTATION DEBUG] send_push_request called for #{name}"
+    puts "[ATTESTATION DEBUG] attestations option: #{options[:attestations]&.any?}, host: #{@host}"
     return super if options[:attestations]&.any? || @host != "https://rubygems.org"
 
     begin
+      puts "[ATTESTATION DEBUG] Attempting attestation-based push"
       send_push_request_with_attestation(name, args)
     rescue StandardError => e
+      puts "[ATTESTATION DEBUG] Attestation failed with error: #{e.class} - #{e.message}"
       alert_warning "Failed to push with attestation, retrying without attestation.\n#{e.full_message}"
       super
     end
   end
 
   def send_push_request_with_attestation(name, args)
+    puts "[ATTESTATION DEBUG] send_push_request_with_attestation called"
     attestation = attest!(name)
+    puts "[ATTESTATION DEBUG] Attestation completed, bundle file: #{attestation}"
     if options[:attestations]
+      puts "[ATTESTATION DEBUG] Adding attestation to options"
       options[:attestations] << attestation
       send_push_request(name, args)
     else
+      puts "[ATTESTATION DEBUG] Sending push with attestation via multipart request"
       rubygems_api_request(*args, scope: get_push_scope) do |request|
         request.set_form([
                            ["gem", Gem.read_binary(name), { filename: name, content_type: "application/octet-stream" }],
@@ -34,24 +42,43 @@ Gem::Commands::PushCommand.prepend(Module.new do
   end
 
   def attest!(name)
+    puts "[ATTESTATION DEBUG] attest! method called for #{name}"
     require "open3"
     require "bundler/inline"
 
-    # Install sigstore-ruby from the GitHub SHA
-    gemfile do
-      gem "sigstore-cli", github: "sigstore/sigstore-ruby", ref: "ce93acf7fa7e26ba81ff21820848d7df2273a557", glob: "cli/sigstore-cli.gemspec"
+    # Install sigstore-cli from the GitHub SHA
+    puts "[ATTESTATION DEBUG] Starting bundler/inline to install sigstore-cli"
+    begin
+      gemfile do
+        gem "sigstore-cli", github: "sigstore/sigstore-ruby", ref: "ce93acf7fa7e26ba81ff21820848d7df2273a557", glob: "cli/sigstore-cli.gemspec"
+      end
+      puts "[ATTESTATION DEBUG] bundler/inline succeeded, gems installed"
+    rescue => e
+      puts "[ATTESTATION DEBUG] bundler/inline failed: #{e.class} - #{e.message}"
+      raise
     end
 
     bundle = "#{name}.sigstore.json"
+    puts "[ATTESTATION DEBUG] Bundle output file will be: #{bundle}"
+
     env = defined?(Bundler.unbundled_env) ? Bundler.unbundled_env : ENV.to_h
+    puts "[ATTESTATION DEBUG] Using unbundled env: #{defined?(Bundler.unbundled_env)}"
+
+    cmd = [Gem.ruby, "-S", "gem", "exec", "sigstore-cli", "sign", name, "--bundle", bundle]
+    puts "[ATTESTATION DEBUG] About to run command: #{cmd.inspect}"
+
     out, st = Open3.capture2e(
       env,
-      Gem.ruby, "-S", "gem", "exec",
-      "sigstore-cli", "sign", name, "--bundle", bundle,
+      *cmd,
       unsetenv_others: true
     )
+
+    puts "[ATTESTATION DEBUG] Command exit status: #{st.exitstatus}"
+    puts "[ATTESTATION DEBUG] Command output:\n#{out}"
+
     raise Gem::Exception, "Failed to sign gem:\n\n#{out}" unless st.success?
 
+    puts "[ATTESTATION DEBUG] Attestation successful, returning bundle: #{bundle}"
     bundle
   end
 end)

--- a/rubygems-attestation-patch.rb
+++ b/rubygems-attestation-patch.rb
@@ -7,30 +7,22 @@ require "rubygems/commands/push_command"
 
 Gem::Commands::PushCommand.prepend(Module.new do
   def send_push_request(name, args)
-    puts "[ATTESTATION DEBUG] send_push_request called for #{name}"
-    puts "[ATTESTATION DEBUG] attestations option: #{options[:attestations]&.any?}, host: #{@host}"
     return super if options[:attestations]&.any? || @host != "https://rubygems.org"
 
     begin
-      puts "[ATTESTATION DEBUG] Attempting attestation-based push"
       send_push_request_with_attestation(name, args)
     rescue StandardError => e
-      puts "[ATTESTATION DEBUG] Attestation failed with error: #{e.class} - #{e.message}"
       alert_warning "Failed to push with attestation, retrying without attestation.\n#{e.full_message}"
       super
     end
   end
 
   def send_push_request_with_attestation(name, args)
-    puts "[ATTESTATION DEBUG] send_push_request_with_attestation called"
     attestation = attest!(name)
-    puts "[ATTESTATION DEBUG] Attestation completed, bundle file: #{attestation}"
     if options[:attestations]
-      puts "[ATTESTATION DEBUG] Adding attestation to options"
       options[:attestations] << attestation
       send_push_request(name, args)
     else
-      puts "[ATTESTATION DEBUG] Sending push with attestation via multipart request"
       rubygems_api_request(*args, scope: get_push_scope) do |request|
         request.set_form([
                            ["gem", Gem.read_binary(name), { filename: name, content_type: "application/octet-stream" }],
@@ -42,43 +34,49 @@ Gem::Commands::PushCommand.prepend(Module.new do
   end
 
   def attest!(name)
-    puts "[ATTESTATION DEBUG] attest! method called for #{name}"
     require "open3"
+    require "tmpdir"
+    require "fileutils"
 
-    # Install sigstore and sigstore-cli from the GitHub SHA
-    puts "[ATTESTATION DEBUG] Installing sigstore from GitHub SHA"
-    install_cmd = [
-      Gem.ruby, "-S", "gem", "install",
-      "--no-document",
-      "git+https://github.com/sigstore/sigstore-ruby.git@ce93acf7fa7e26ba81ff21820848d7df2273a557"
-    ]
-    puts "[ATTESTATION DEBUG] Running: #{install_cmd.inspect}"
-    out, st = Open3.capture2e(*install_cmd)
-    puts "[ATTESTATION DEBUG] Install output:\n#{out}"
-    raise Gem::Exception, "Failed to install sigstore from GitHub:\n\n#{out}" unless st.success?
-    puts "[ATTESTATION DEBUG] Gem installation succeeded"
+    # Clone sigstore-ruby from GitHub at the specified SHA
+    tmpdir = Dir.mktmpdir("sigstore-ruby-")
+    clone_cmd = ["git", "clone", "https://github.com/sigstore/sigstore-ruby.git", tmpdir]
+    out, st = Open3.capture2e(*clone_cmd)
+    raise Gem::Exception, "Failed to clone sigstore-ruby:\n\n#{out}" unless st.success?
+
+    # Checkout the specific SHA
+    checkout_cmd = ["git", "-C", tmpdir, "checkout", "ce93acf7fa7e26ba81ff21820848d7df2273a557"]
+    out, st = Open3.capture2e(*checkout_cmd)
+    raise Gem::Exception, "Failed to checkout SHA:\n\n#{out}" unless st.success?
+
+    # Add sigstore-ruby lib directories to load path
+    sigstore_lib = File.join(tmpdir, "lib")
+    cli_lib = File.join(tmpdir, "cli", "lib")
+    $LOAD_PATH.unshift(sigstore_lib, cli_lib)
+
+    # Require the sigstore CLI code
+    begin
+      require "sigstore/cli"
+    rescue => e
+      raise Gem::Exception, "Failed to load sigstore CLI: #{e.message}"
+    end
 
     bundle = "#{name}.sigstore.json"
-    puts "[ATTESTATION DEBUG] Bundle output file will be: #{bundle}"
 
-    env = defined?(Bundler.unbundled_env) ? Bundler.unbundled_env : ENV.to_h
-    puts "[ATTESTATION DEBUG] Using unbundled env: #{defined?(Bundler.unbundled_env)}"
+    # Call the CLI directly with the sign command
+    begin
+      Sigstore::CLI.start(["sign", name, "--bundle", bundle])
+    rescue SystemExit => e
+      raise Gem::Exception, "Failed to sign gem: CLI exited with status #{e.status}" unless e.status == 0
+    rescue => e
+      raise Gem::Exception, "Failed to sign gem: #{e.message}"
+    end
 
-    cmd = [Gem.ruby, "-S", "gem", "exec", "sigstore-cli", "sign", name, "--bundle", bundle]
-    puts "[ATTESTATION DEBUG] About to run command: #{cmd.inspect}"
-
-    out, st = Open3.capture2e(
-      env,
-      *cmd,
-      unsetenv_others: true
-    )
-
-    puts "[ATTESTATION DEBUG] Command exit status: #{st.exitstatus}"
-    puts "[ATTESTATION DEBUG] Command output:\n#{out}"
-
-    raise Gem::Exception, "Failed to sign gem:\n\n#{out}" unless st.success?
-
-    puts "[ATTESTATION DEBUG] Attestation successful, returning bundle: #{bundle}"
     bundle
+  ensure
+    # Clean up the temporary directory
+    if defined?(tmpdir) && tmpdir && File.directory?(tmpdir)
+      FileUtils.rm_rf(tmpdir) rescue nil
+    end
   end
 end)

--- a/rubygems-attestation-patch.rb
+++ b/rubygems-attestation-patch.rb
@@ -35,12 +35,19 @@ Gem::Commands::PushCommand.prepend(Module.new do
 
   def attest!(name)
     require "open3"
+    require "bundler/inline"
+
+    # Install sigstore-ruby from the GitHub SHA
+    gemfile do
+      gem "sigstore-cli", github: "sigstore/sigstore-ruby", ref: "ce93acf7fa7e26ba81ff21820848d7df2273a557", glob: "cli/sigstore-cli.gemspec"
+    end
+
     bundle = "#{name}.sigstore.json"
     env = defined?(Bundler.unbundled_env) ? Bundler.unbundled_env : ENV.to_h
     out, st = Open3.capture2e(
       env,
       Gem.ruby, "-S", "gem", "exec",
-      "sigstore-cli:0.2.1", "sign", name, "--bundle", bundle,
+      "sigstore-cli", "sign", name, "--bundle", bundle,
       unsetenv_others: true
     )
     raise Gem::Exception, "Failed to sign gem:\n\n#{out}" unless st.success?

--- a/rubygems-attestation-patch.rb
+++ b/rubygems-attestation-patch.rb
@@ -44,20 +44,27 @@ Gem::Commands::PushCommand.prepend(Module.new do
   def attest!(name)
     puts "[ATTESTATION DEBUG] attest! method called for #{name}"
     require "open3"
-    require "bundler/inline"
 
-    # Install sigstore-cli from the GitHub SHA
-    puts "[ATTESTATION DEBUG] Starting bundler/inline to install sigstore-cli"
-    begin
-      gemfile do
-        source "https://rubygems.org"
-        gem "sigstore-cli", github: "sigstore/sigstore-ruby", ref: "ce93acf7fa7e26ba81ff21820848d7df2273a557", glob: "cli/sigstore-cli.gemspec"
-      end
-      puts "[ATTESTATION DEBUG] bundler/inline succeeded, gems installed"
-    rescue => e
-      puts "[ATTESTATION DEBUG] bundler/inline failed: #{e.class} - #{e.message}"
-      raise
-    end
+    # Install specific_install gem
+    puts "[ATTESTATION DEBUG] Installing specific_install gem"
+    install_specific_install = [Gem.ruby, "-S", "gem", "install", "specific_install", "--no-document"]
+    puts "[ATTESTATION DEBUG] Running: #{install_specific_install.inspect}"
+    out, st = Open3.capture2e(*install_specific_install)
+    puts "[ATTESTATION DEBUG] specific_install install output:\n#{out}"
+    raise Gem::Exception, "Failed to install specific_install:\n\n#{out}" unless st.success?
+
+    # Use specific_install to install sigstore from the GitHub SHA
+    puts "[ATTESTATION DEBUG] Using specific_install to install sigstore from GitHub SHA"
+    specific_install_cmd = [
+      Gem.ruby, "-S", "gem", "specific_install",
+      "-l", "https://github.com/sigstore/sigstore-ruby",
+      "-b", "ce93acf7fa7e26ba81ff21820848d7df2273a557"
+    ]
+    puts "[ATTESTATION DEBUG] Running: #{specific_install_cmd.inspect}"
+    out, st = Open3.capture2e(*specific_install_cmd)
+    puts "[ATTESTATION DEBUG] specific_install output:\n#{out}"
+    raise Gem::Exception, "Failed to install sigstore from GitHub:\n\n#{out}" unless st.success?
+    puts "[ATTESTATION DEBUG] Gem installation succeeded"
 
     bundle = "#{name}.sigstore.json"
     puts "[ATTESTATION DEBUG] Bundle output file will be: #{bundle}"

--- a/rubygems-attestation-patch.rb
+++ b/rubygems-attestation-patch.rb
@@ -50,6 +50,7 @@ Gem::Commands::PushCommand.prepend(Module.new do
     puts "[ATTESTATION DEBUG] Starting bundler/inline to install sigstore-cli"
     begin
       gemfile do
+        source "https://rubygems.org"
         gem "sigstore-cli", github: "sigstore/sigstore-ruby", ref: "ce93acf7fa7e26ba81ff21820848d7df2273a557", glob: "cli/sigstore-cli.gemspec"
       end
       puts "[ATTESTATION DEBUG] bundler/inline succeeded, gems installed"


### PR DESCRIPTION
sigstore-ruby has fallen out of step with the upstream Sigstore servers. Patches have been applied, but a new release needs to be made before this Action can rely on the gem itself. In the meantime, we can point to the specific SHA to get the desired behavior.

The intention of this change is for it to be temporary.