### PR TITLE
Update sigstore-cli to unblock attestations

### DIFF
--- a/rubygems-attestation-patch.rb
+++ b/rubygems-attestation-patch.rb
@@ -40,7 +40,7 @@ Gem::Commands::PushCommand.prepend(Module.new do
     out, st = Open3.capture2e(
       env,
       Gem.ruby, "-S", "gem", "exec",
-      "sigstore-cli:0.2.1", "sign", name, "--bundle", bundle,
+      "sigstore-cli:0.2.2", "sign", name, "--bundle", bundle,
       unsetenv_others: true
     )
     raise Gem::Exception, "Failed to sign gem:\n\n#{out}" unless st.success?


### PR DESCRIPTION
sigstore-ruby v0.2.1 wasn't able to handle some keys which were being served by Sigstore. As a result, attestations have been failing since October 10th. There are fixes in v0.2.2, which should unblock attestations.

Closes #24 