### PR TITLE
use `--force` flag with `git fetch --tags` to avoid tag clobber error

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ runs:
         git config --local credential.helper 'cache --timeout=300'
       shell: bash
     - name: Fetch tags
-      run: git fetch --tags
+      run: git fetch --tags --force
       shell: bash
     - name: Configure trusted publishing credentials
       if: ${{ inputs.setup-trusted-publisher == 'true' }}


### PR DESCRIPTION
When a workflow is triggered by a tag push, the tag already exists locally after checkout. `git fetch --tags` then fails with "would clobber existing tag" for that tag. Adding --force allows the fetch to overwrite the existing local tag.