### PR TITLE
Add opt-in version check to verify tag matches gem VERSION

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,34 @@ jobs:
       - uses: rubygems/release-gem@v1
 ```
 
+### Inputs
+
+| Input | Description | Default |
+|---|---|---|
+| `await-release` | Whether to poll for the release to be available on RubyGems.org | `true` |
+| `check-version` | Whether to verify the git tag matches the gem's VERSION before releasing | `false` |
+| `setup-trusted-publisher` | Whether to setup the trusted publisher for the gem | `true` |
+| `attestations` | Enable experimental support for sigstore attestations | `true` |
+
+### Version Check
+
+When `check-version` is enabled, the action verifies that the git tag triggering the
+release matches the version in your gemspec before publishing. This prevents accidentally
+publishing a gem whose version does not match the release tag.
+
+```yaml
+- uses: rubygems/release-gem@v1
+  with:
+    check-version: true
+```
+
+The check supports common tag formats:
+- `v1.2.3` (standard Bundler convention)
+- `1.2.3` (bare version)
+- `my-gem-v1.2.3` or `my-gem/v1.2.3` (monorepo-style prefixes)
+
+If the workflow is not triggered by a tag push, the check is skipped.
+
 ### Requirements
 
 For now, this action makes several assumptions about your project:

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: "Whether to poll for the release to be available on RubyGems.org"
     required: false
     default: "true"
+  check-version:
+    description: "Whether to verify the git tag matches the gem's VERSION before releasing"
+    required: false
+    default: "false"
   setup-trusted-publisher:
     description: "Whether to setup the trusted publisher for the gem"
     required: false
@@ -45,6 +49,25 @@ runs:
     - name: Configure trusted publishing credentials
       if: ${{ inputs.setup-trusted-publisher == 'true' }}
       uses: rubygems/configure-rubygems-credentials@v1.0.0
+    - name: Verify tag matches gem version
+      if: ${{ inputs.check-version == 'true' && startsWith(github.ref, 'refs/tags/') }}
+      run: |
+        gem_version=$(ruby -e "spec = Gem::Specification.load(Dir['*.gemspec'].first); puts spec.version")
+        tag="${GITHUB_REF_NAME}"
+        # Strip optional prefix (e.g., "gem-name-" or "gem-name/") and optional "v" prefix
+        tag_version=$(echo "$tag" | sed -E 's/^(.*[-\/])?v//' )
+        # If no prefix was stripped, try without the v requirement
+        if [ "$tag_version" = "$tag" ]; then
+          tag_version="$tag"
+        fi
+
+        if [ "$gem_version" != "$tag_version" ]; then
+          echo "::error::Tag ($tag) version ($tag_version) does not match gem version ($gem_version)"
+          exit 1
+        fi
+
+        echo "Tag ($tag) version ($tag_version) matches gem version ($gem_version)"
+      shell: bash
     - name: Run release rake task
       run: bundle exec rake release
       shell: bash


### PR DESCRIPTION
## Summary

- Adds a `check-version` input (default `false`) that verifies the git tag matches the gemspec version before publishing
- Handles common tag formats: `v1.2.3`, bare `1.2.3`, and monorepo-style prefixes like `my-gem-v1.2.3`
- Skips the check when the workflow is not triggered by a tag push
- Documents the new input and version check feature in the README

## Justification

Prevents accidentally publishing a gem whose version does not match the release tag. This is an opt-in safeguard, so existing workflows are unaffected.

## Technical Details

The check loads the gemspec via `Gem::Specification.load` to extract the version, then strips known tag prefixes (`v`, monorepo-style `name-v` or `name/v`) before comparing. The step only runs when `check-version: true` and the workflow is triggered by a tag ref.

Closes #14