### PR TITLE
Add configurable token input for git authentication

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,13 @@
 name: "Release Gem"
 description: "Upload gems to RubyGems.org"
 inputs:
+  token:
+    description: >-
+      GitHub token used to authenticate git operations (e.g. pushing the release tag).
+      Defaults to the built-in github.token. Override with a PAT or GitHub App token
+      when tag push protection rules require a specific actor or bypass permission.
+    required: false
+    default: ${{ github.token }}
   await-release:
     description: "Whether to poll for the release to be available on RubyGems.org"
     required: false
@@ -34,7 +41,7 @@ runs:
         protocol=https
         host=github.com
         username=x-access-token
-        password=${{ github.token }}
+        password=${{ inputs.token }}
 
         EOF
         git config --local credential.helper 'cache --timeout=300'


### PR DESCRIPTION
**Why**

The action currently hardcodes `${{ github.token }}` for git credentials, which authenticates as `github-actions[bot]`. This works fine by default, but breaks when repositories have tag push protection configured (classic tag rules or rulesets).

When `bundle exec rake release` pushes the version tag, GitHub evaluates the pushing actor against the protection rules. If `github-actions[bot]` isn't an explicit bypass actor — or if the ruleset requires a human actor, signed tags, or a specific app — the tag push is rejected with a 403. The action had no escape hatch for this; the only workaround was forking it.

**How**

Add an optional token input that defaults to `${{ github.token }}`, preserving existing behavior for all current users. Callers who need a different identity (fine-grained PAT, GitHub App installation token) can now pass it explicitly:

```
  - uses: rubygems/release-gem@v1
    with:
      token: ${{ secrets.RELEASE_PAT }}
```

The credential-cache step now uses `${{ inputs.token }}` instead of the hardcoded `${{ github.token }}`.

**What doesn't change**

  - Default behavior is identical — no action required from existing users
  - No other authentication paths (trusted publishing, RubyGems credentials) are affected
  - The token is only used for the git push --tags operation performed by rake release