### PR TITLE
Pin `rubygems/configure-rubygems-credentials` to a commit SHA

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ runs:
       shell: bash
     - name: Configure trusted publishing credentials
       if: ${{ inputs.setup-trusted-publisher == 'true' }}
-      uses: rubygems/configure-rubygems-credentials@v1.0.0
+      uses: rubygems/configure-rubygems-credentials@bc6dd217f8a4f919d6835fcfefd470ef821f5c44 # v1.0.0
     - name: Run release rake task
       run: bundle exec rake release
       shell: bash


### PR DESCRIPTION
This action is currently unusable in organizations that have enabled the [Require actions to be pinned to a full-length commit SHA](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#managing-github-actions-permissions-for-your-repository) setting for security purposes.

This PR pins the `rubygems/configure-rubygems-credentials` action to bring it into compliance.