### PR TITLE
fix: load bundler/setup before attestation patch to prevent default gem conflict

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,10 @@ runs:
     - name: Configure trusted publishing credentials
       if: ${{ inputs.setup-trusted-publisher == 'true' }}
       uses: rubygems/configure-rubygems-credentials@dc5a8d8553e6ee01fc26761a49e99e733d17954a # v2.1.0
+    - name: Install dependencies
+      run: bundle install
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
     - name: Run release rake task
       run: bundle exec rake release
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -60,7 +60,7 @@ runs:
       run: bundle exec rake release
       shell: bash
       env:
-        RUBYOPT: "${{ inputs.attestations == 'true' && format('-r{0}/rubygems-attestation-patch.rb {1}', github.action_path, env.RUBYOPT) || env.RUBYOPT }}"
+        RUBYOPT: "${{ inputs.attestations == 'true' && format('-rbundler/setup -r{0}/rubygems-attestation-patch.rb {1}', github.action_path, env.RUBYOPT) || env.RUBYOPT }}"
       working-directory: ${{ inputs.working-directory }}
     - name: Wait for release to propagate
       if: ${{ inputs.await-release == 'true' }}


### PR DESCRIPTION
#### Overview

Hi!

resolve: https://github.com/rubygems/release-gem/issues/28

This PR modifies that Bundler activates gems with Gemfile at first. If a default gem is listed as a dependency in your Gemfile, activation conflicts will no longer occur.


#### Problem

RUBYOPT loads rubygems-attestation-patch.rb before Bundler has activated the gems specified in the Gemfile. The file contains  `require "rubygems/commands/push_command"` which activates the default openssl of ruby-version.

And Bundler tries to activate the openssl version specified in the Gemfile, a conflict occurs.

>   You have already activated openssl 4.0.0, but your Gemfile requires openssl 3.3.2. Since openssl is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports openssl as a default gem. (Gem::LoadError)


#### Solution

I prepend `-rbundler/setup` to RUBYOPT.

Bundler activates the gems specified in the Gemfile, including openssl, before rubygems-attestation-patch.rb is loaded, resolving the version conflict.