### PR TITLE
Bump rubygems/configure-rubygems-credentials from 2.0.0 to 2.1.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ runs:
       shell: bash
     - name: Configure trusted publishing credentials
       if: ${{ inputs.setup-trusted-publisher == 'true' }}
-      uses: rubygems/configure-rubygems-credentials@762a4b77c3300434bb57c7ce80b20e36231927aa # v2.0.0
+      uses: rubygems/configure-rubygems-credentials@dc5a8d8553e6ee01fc26761a49e99e733d17954a # v2.1.0
     - name: Run release rake task
       run: bundle exec rake release
       shell: bash


### PR DESCRIPTION
This updates the SHA pin for rubygems/configure-rubygems-credentials to [v2.1.0](https://github.com/rubygems/configure-rubygems-credentials/releases/tag/v2.1.0) (dc5a8d8553e6ee01fc26761a49e99e733d17954a). The new release switches the action runtime from node20 to node24 (rubygems/configure-rubygems-credentials#421), which removes the Node.js 20 deprecation warning that has been shown on every workflow run for all users of release-gem with trusted publishing enabled.

Note that GitHub will switch JavaScript actions to run on Node 24 by default starting 2026-06-16. The node24 runtime requires actions/runner 2.327.1 or later on self-hosted runners; GitHub-hosted runners are not affected.

Since users referencing `rubygems/release-gem@v1` track the v1 branch directly, merging this is effectively a release for them. For users pinning exact versions, a follow-up tag and release (e.g. v1.3.1) should be cut after merging, as was done for v1.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)