### PR TITLE
Skip the attestation patch when RubyGems signs on its own

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,8 @@ inputs:
       [EXPERIMENTAL]
       Enable experimental support for sigstore attestations.
       Only works with RubyGems.org via Trusted Publishing.
+      No effect on RubyGems versions that sign on their own; they attest
+      whether or not this is set.
     required: false
     default: "true"
   working-directory:

--- a/rubygems-attestation-patch.rb
+++ b/rubygems-attestation-patch.rb
@@ -5,6 +5,16 @@ return unless defined?(Gem)
 
 require "rubygems/commands/push_command"
 
+# RubyGems 4.1.0.dev signs on its own, and its #send_push_request delegates to
+# a #send_push_request_with_attestation of its own.  Prepending a method of
+# that name in front of it makes the two call each other forever: the patch
+# delegates up with `super`, RubyGems delegates back down by name, and every
+# lap signs the gem again.  Leave the newer RubyGems to it.
+if Gem::Commands::PushCommand.private_method_defined?(:send_push_request_with_attestation) ||
+   Gem::Commands::PushCommand.method_defined?(:send_push_request_with_attestation)
+  return
+end
+
 Gem::Commands::PushCommand.prepend(Module.new do
   def send_push_request(name, args)
     return super if options[:attestations]&.any? || @host != "https://rubygems.org"


### PR DESCRIPTION
RubyGems 4.1.0.dev grew attestation support, and its #send_push_request delegates to a #send_push_request_with_attestation of its own. This patch prepends a method of that same name, so the two call each other forever: the patch delegates up with `super`, RubyGems delegates back down by name, and every lap runs attest! again. A release on ruby-head spent 71 minutes signing the same gem over and over before dying with SystemStackError, ~9,500 frames deep.

Detect that method and leave the newer RubyGems to it. Nothing changes on versions without it: RubyGems 4.0.10 has no such method, so the patch still applies there and pushes the attestation through the options[:attestations] path as before.

Both visibilities are checked because RubyGems keeps the method private today, and recursion is too costly a way to find out that it stopped.

Fixes #41